### PR TITLE
Deployment: Fix Shipit link

### DIFF
--- a/automation/deployment.md
+++ b/automation/deployment.md
@@ -26,7 +26,7 @@ There are many different tools for this for many different programming languages
 
 - [Fabric](http://www.fabfile.org/) (Python)
 - [Capistrano](http://capistranorb.com/) (Ruby)
-- [Shipit](http://www.fabfile.org/) (Node.js)
+- [Shipit](https://github.com/shipitjs/shipit) (Node.js)
 - [Edeliver](https://github.com/boldpoker/edeliver) (Elixir and Erlang)
 
 It doesn't matter which solution you pick, as long as your project's deployments are easy, automated, and reliable.


### PR DESCRIPTION
Shipit is incorrectly pointing to Fabric's site. This PR corrects the link by pointing it to Shipit's GitHub repository.